### PR TITLE
Add API to retrieve account, gateway and mapper rewards

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,7 @@ import (
 	gatewayapi "github.com/ThingsIXFoundation/data-aggregator/gateway/api"
 	mapperapi "github.com/ThingsIXFoundation/data-aggregator/mapper/api"
 	mappingapi "github.com/ThingsIXFoundation/data-aggregator/mapping/api"
+	rewardapi "github.com/ThingsIXFoundation/data-aggregator/rewards/api"
 	routerapi "github.com/ThingsIXFoundation/data-aggregator/router/api"
 	httputils "github.com/ThingsIXFoundation/http-utils"
 	"github.com/ThingsIXFoundation/http-utils/cache"
@@ -40,6 +41,7 @@ type API struct {
 	routerAPI  *routerapi.RouterAPI
 	mapperAPI  *mapperapi.MapperAPI
 	mappingAPI *mappingapi.MappingAPI
+	rewardAPI  *rewardapi.RewardsAPI
 }
 
 func NewAPI() (*API, error) {
@@ -79,7 +81,15 @@ func NewAPI() (*API, error) {
 		}
 
 		api.mappingAPI = mappingAPI
+	}
 
+	if viper.GetBool(config.CONFIG_REWARD_API_ENABLED) {
+		rewardAPI, err := rewardapi.NewRewardsAPI()
+		if err != nil {
+			return nil, err
+		}
+
+		api.rewardAPI = rewardAPI
 	}
 
 	return api, nil
@@ -121,6 +131,10 @@ func (a *API) Serve(ctx context.Context) chan error {
 
 	if a.mappingAPI != nil {
 		a.mappingAPI.Bind(root)
+	}
+
+	if a.rewardAPI != nil {
+		a.rewardAPI.Bind(root)
 	}
 
 	stopped := make(chan error)

--- a/clouddatastore/index.yaml
+++ b/clouddatastore/index.yaml
@@ -69,6 +69,16 @@ indexes:
     - name: Account
     - name: Date
       direction: desc
+- kind: MapperRewardHistory
+  properties:
+    - name: MapperID
+    - name: Date
+      direction: desc
+- kind: GatewayRewardHistory
+  properties:
+    - name: GatewayID
+    - name: Date
+      direction: desc
 - kind: AssumedGatewayCoverageHistory
   properties:
     - name: Date

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ const (
 	CONFIG_GATEWAY_CHAINSYNC_POLL_INTERVAL         = "gateway.chainsync.poll-interval"
 	CONFIG_GATEWAY_STORE                           = "gateway.store.type"
 	CONFIG_GATEWAY_STORE_DEFAULT                   = "clouddatastore"
+	CONFIG_REWARD_API_ENABLED                      = "reward.api.enabled"
 
 	CONFIG_ROUTER_CONTRACT                        = "router.contract"
 	CONFIG_ROUTER_API_ENABLED                     = "router.api.enabled"
@@ -122,6 +123,7 @@ func PersistentFlags(flags *pflag.FlagSet) {
 	flags.Uint64(CONFIG_GATEWAY_CHAINSYNC_MAX_BLOCK_SCAN_RANGE, 10000, "the number of blocks to scan at most at once")
 	flags.Duration(CONFIG_GATEWAY_CHAINSYNC_POLL_INTERVAL, 1*time.Minute, "the interval to poll the RPC node for new transactions")
 	flags.String(CONFIG_GATEWAY_STORE, CONFIG_GATEWAY_STORE_DEFAULT, "the store to use")
+	flags.Bool(CONFIG_REWARD_API_ENABLED, true, "enable the API for rewards")
 
 	flags.String(CONFIG_ROUTER_CONTRACT, "", "the address of the router registry contract")
 	flags.Bool(CONFIG_ROUTER_API_ENABLED, true, "enable the API for routers")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ThingsIXFoundation/frequency-plan v1.4.1
 	github.com/ThingsIXFoundation/http-utils v0.0.0-20230206101704-4a5e41dfc150
 	github.com/ThingsIXFoundation/packet-handling v1.0.8
-	github.com/ThingsIXFoundation/types v0.0.0-20230403181540-e66ccd088c16
+	github.com/ThingsIXFoundation/types v0.0.0-20230412110447-7c624be496c5
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/ethereum/go-ethereum v1.11.5
 	github.com/spf13/pflag v1.0.5
@@ -60,10 +60,10 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
-	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230322174352-cde4c949918d // indirect
@@ -88,6 +88,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
-	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/Kl1mn/h3-go v0.0.4/go.mod h1:z7OGXqLd+5hur6EB8s3wFftUEzmfdZ0CMrExBxme
 github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:w5D10RxC0NmPYxmQ438CC1S07zaC1zpvuNW7s5sUk2Q=
 github.com/ThingsIXFoundation/frequency-plan v1.4.1 h1:mlfBZgjUVH+c/mX7K2jrpW9GgpuLCRWsR9CcmGYRoO8=
 github.com/ThingsIXFoundation/frequency-plan v1.4.1/go.mod h1:3dsy1m1xHkUt1skc3o8Q3lzhjCXTwsDin83wyN2HmB4=
+github.com/ThingsIXFoundation/frequency-plan/go v0.0.0-20221031153149-5c3c9946d37f h1:kGy+tDtpo089fY5oiEaJksCsDy3psJoK70ZZaSrFllY=
 github.com/ThingsIXFoundation/gateway-registry-go v1.0.0 h1:cRUoWP8d8HuE00frR1lSZPHlMaW44Kr/lavavzHkEOg=
 github.com/ThingsIXFoundation/gateway-registry-go v1.0.0/go.mod h1:/d0dfBbjyrZL1DU+Ct4ORT/dFBT7b+N9cH97r3M+wxo=
 github.com/ThingsIXFoundation/h3-light v0.0.0-20230404055559-b4bb7d4d9c47 h1:mMDINoE7UCVk3fxy5m0X62T+f4BLTkGVnw1H2Llcv4k=
@@ -73,6 +74,8 @@ github.com/ThingsIXFoundation/router-registry-go v1.1.0 h1:zWZMhrc4ZuLVR5X2hsu1T
 github.com/ThingsIXFoundation/router-registry-go v1.1.0/go.mod h1:JA8B+SBQEL1MAvHrbNw053bSzq++BBwW7QJ/s7BH018=
 github.com/ThingsIXFoundation/types v0.0.0-20230403181540-e66ccd088c16 h1:v95qvL2jdZqlOjkiTGKvlXdOMiriC/FqRqgvUySlfyI=
 github.com/ThingsIXFoundation/types v0.0.0-20230403181540-e66ccd088c16/go.mod h1:ANUUB8Cnm1sCb5ifS5RUjzTgT9u4BCams2tEJ0M5uqk=
+github.com/ThingsIXFoundation/types v0.0.0-20230412110447-7c624be496c5 h1:YFEUFpo6FsHFWJS/fv1qH8o40xY0zQjJXgD1hNZ/OMQ=
+github.com/ThingsIXFoundation/types v0.0.0-20230412110447-7c624be496c5/go.mod h1:ANUUB8Cnm1sCb5ifS5RUjzTgT9u4BCams2tEJ0M5uqk=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -400,6 +403,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
+golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -473,6 +478,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
+golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/oauth2 v0.0.0-20170912212905-13449ad91cb2/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -546,6 +553,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -557,6 +566,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20170424234030-8be79e1e0910/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/mapping/api/v1_coverage.go
+++ b/mapping/api/v1_coverage.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/mapping/api/v1_map.go
+++ b/mapping/api/v1_map.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/mapping/store/clouddatastore/models/assumed_coverage_history.go
+++ b/mapping/store/clouddatastore/models/assumed_coverage_history.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (

--- a/mapping/store/clouddatastore/models/assumed_gateway_coverage_history.go
+++ b/mapping/store/clouddatastore/models/assumed_gateway_coverage_history.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (

--- a/rewards/api/api.go
+++ b/rewards/api/api.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"github.com/ThingsIXFoundation/data-aggregator/rewards/store"
+	"github.com/ThingsIXFoundation/types"
+	"github.com/go-chi/chi/v5"
+)
+
+type RewardsAPI struct {
+	store store.Store
+}
+
+func NewRewardsAPI() (*RewardsAPI, error) {
+	store, err := store.NewStore()
+	if err != nil {
+		return nil, err
+	}
+	return &RewardsAPI{
+		store: store,
+	}, nil
+}
+
+func (rapi *RewardsAPI) Bind(root *chi.Mux) error {
+	root.Route("/rewards", func(r chi.Router) {
+		r.Route("/v1", func(r chi.Router) {
+			r.Route("/accounts", func(r chi.Router) {
+				r.Get("/{account:(?i)(0x)?[0-9a-f]{40}}", rapi.LatestAccountRewards)
+			})
+			r.Route("/gateways", func(r chi.Router) {
+				r.Get("/{gatewayID:(?i)(0x)?[0-9a-f]{64}}", rapi.LatestGatewayRewards)
+			})
+			r.Route("/mappers", func(r chi.Router) {
+				r.Get("/{mapperID:(?i)(0x)?[0-9a-f]{64}}", rapi.LatestMapperRewards)
+			})
+		})
+	})
+
+	return nil
+}
+
+var (
+	emptyAccountRewards = make([]*types.AccountRewardHistory, 0)
+	emptyGatewayRewards = make([]*types.GatewayRewardHistory, 0)
+	emptyMapperRewards  = make([]*types.MapperRewardHistory, 0)
+)
+
+func accountRewardsOrEmptySlice(rewards []*types.AccountRewardHistory) []*types.AccountRewardHistory {
+	if len(rewards) == 0 {
+		return emptyAccountRewards
+	}
+	return rewards
+}
+
+func gatewayRewardsOrEmptySlice(rewards []*types.GatewayRewardHistory) []*types.GatewayRewardHistory {
+	if len(rewards) == 0 {
+		return emptyGatewayRewards
+	}
+	return rewards
+}
+
+func mapperRewardsOrEmptySlice(rewards []*types.MapperRewardHistory) []*types.MapperRewardHistory {
+	if len(rewards) == 0 {
+		return emptyMapperRewards
+	}
+	return rewards
+}

--- a/rewards/api/v1.go
+++ b/rewards/api/v1.go
@@ -1,0 +1,142 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ThingsIXFoundation/http-utils/encoding"
+	"github.com/ThingsIXFoundation/http-utils/logging"
+	"github.com/ThingsIXFoundation/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-chi/chi/v5"
+	"github.com/sirupsen/logrus"
+)
+
+func (rapi *RewardsAPI) LatestAccountRewards(w http.ResponseWriter, r *http.Request) {
+	var (
+		ctx, cancel = context.WithTimeout(r.Context(), 15*time.Second)
+		account     = common.HexToAddress(chi.URLParam(r, "account"))
+		cursor      = r.URL.Query().Get("cursor")
+		pageSize, _ = strconv.Atoi(r.URL.Query().Get("pageSize"))
+		log         = logging.WithContext(r.Context()).WithFields(logrus.Fields{
+			"account":  account,
+			"pageSize": pageSize,
+		})
+	)
+
+	defer cancel()
+
+	if pageSize == 0 || pageSize > 100 {
+		pageSize = 15
+	}
+
+	rewards, cursor, err := rapi.store.GetAccountRewards(ctx, account, pageSize, cursor)
+	if err != nil {
+		log.WithError(err).Error("error when getting latest account rewards")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if cursor != "" {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"cursor":  cursor,
+			"rewards": accountRewardsOrEmptySlice(rewards),
+		})
+	} else {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"rewards": accountRewardsOrEmptySlice(rewards),
+		})
+	}
+}
+
+func (rapi *RewardsAPI) LatestGatewayRewards(w http.ResponseWriter, r *http.Request) {
+	var (
+		ctx, cancel = context.WithTimeout(r.Context(), 15*time.Second)
+		gatewayID   = types.IDFromString(chi.URLParam(r, "gatewayID"))
+		cursor      = r.URL.Query().Get("cursor")
+		pageSize, _ = strconv.Atoi(r.URL.Query().Get("pageSize"))
+		log         = logging.WithContext(r.Context()).WithFields(logrus.Fields{
+			"gateway":  gatewayID,
+			"pageSize": pageSize,
+		})
+	)
+
+	defer cancel()
+
+	if pageSize == 0 || pageSize > 100 {
+		pageSize = 15
+	}
+
+	rewards, cursor, err := rapi.store.GetGatewayRewards(ctx, gatewayID, pageSize, cursor)
+	if err != nil {
+		log.WithError(err).Error("error when getting latest gateway rewards")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if cursor != "" {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"cursor":  cursor,
+			"rewards": gatewayRewardsOrEmptySlice(rewards),
+		})
+	} else {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"rewards": gatewayRewardsOrEmptySlice(rewards),
+		})
+	}
+}
+
+func (rapi *RewardsAPI) LatestMapperRewards(w http.ResponseWriter, r *http.Request) {
+	var (
+		ctx, cancel = context.WithTimeout(r.Context(), 15*time.Second)
+		mapperID    = types.IDFromString(chi.URLParam(r, "mapperID"))
+		cursor      = r.URL.Query().Get("cursor")
+		pageSize, _ = strconv.Atoi(r.URL.Query().Get("pageSize"))
+		log         = logging.WithContext(r.Context()).WithFields(logrus.Fields{
+			"mapper":   mapperID,
+			"pageSize": pageSize,
+		})
+	)
+
+	defer cancel()
+
+	if pageSize == 0 || pageSize > 100 {
+		pageSize = 15
+	}
+
+	rewards, cursor, err := rapi.store.GetMapperRewards(ctx, mapperID, pageSize, cursor)
+	if err != nil {
+		log.WithError(err).Error("error when getting latest mapper rewards")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if cursor != "" {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"cursor":  cursor,
+			"rewards": mapperRewardsOrEmptySlice(rewards),
+		})
+	} else {
+		encoding.ReplyJSON(w, r, http.StatusOK, map[string]interface{}{
+			"rewards": mapperRewardsOrEmptySlice(rewards),
+		})
+	}
+}

--- a/rewards/store/clouddatastore/models/account_reward_history.go
+++ b/rewards/store/clouddatastore/models/account_reward_history.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (
@@ -5,6 +21,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ThingsIXFoundation/data-aggregator/utils"
 	"github.com/ThingsIXFoundation/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -21,10 +38,10 @@ type DBAccountRewardHistory struct {
 
 func NewDBAccountRewardHistory(e *types.AccountRewardHistory) *DBAccountRewardHistory {
 	return &DBAccountRewardHistory{
-		Account:      e.Account.String(),
+		Account:      utils.AddressToString(e.Account),
 		Rewards:      e.Rewards.String(),
 		TotalRewards: e.TotalRewards.String(),
-		Processor:    e.Processor.String(),
+		Processor:    utils.AddressToString(e.Processor),
 		Signature:    e.Signature,
 		Date:         e.Date,
 	}

--- a/rewards/store/clouddatastore/models/gateway_reward_history.go
+++ b/rewards/store/clouddatastore/models/gateway_reward_history.go
@@ -1,7 +1,24 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ThingsIXFoundation/types"
@@ -37,4 +54,26 @@ func NewDBGatewayRewardHistory(e *types.GatewayRewardHistory) *DBGatewayRewardHi
 		AssumedCoverageShareUnits: e.AssumedCoverageShareUnits.String(),
 		Rewards:                   e.Rewards.String(),
 	}
+}
+
+func (m DBGatewayRewardHistory) GatewayRewardHistory() (*types.GatewayRewardHistory, error) {
+	assumedCoverageShareUnits, ok := new(big.Int).SetString(m.AssumedCoverageShareUnits, 0)
+	if !ok {
+		return nil, fmt.Errorf("invalid assumed coverage shared units value")
+	}
+	rewards, ok := new(big.Int).SetString(m.Rewards, 0)
+	if !ok {
+		return nil, fmt.Errorf("invalid rewards units value")
+	}
+
+	return &types.GatewayRewardHistory{
+		// ID of the gateway
+		GatewayID: types.IDFromString(m.GatewayID),
+		// Date these rewards where issued
+		Date: m.Date,
+		// The total amount of Coverage Share Units this gateway has a the date.
+		AssumedCoverageShareUnits: assumedCoverageShareUnits,
+		// The reward in THIX "gweis" for this gateway
+		Rewards: rewards,
+	}, nil
 }

--- a/rewards/store/clouddatastore/models/mapper_reward_history.go
+++ b/rewards/store/clouddatastore/models/mapper_reward_history.go
@@ -1,7 +1,24 @@
+// Copyright 2023 Stichting ThingsIX Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package models
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ThingsIXFoundation/types"
@@ -37,4 +54,26 @@ func NewDBMapperRewardHistory(e *types.MapperRewardHistory) *DBMapperRewardHisto
 		MappingUnits: e.MappingUnits.String(),
 		Rewards:      e.Rewards.String(),
 	}
+}
+
+func (m DBMapperRewardHistory) MapperRewardHistory() (*types.MapperRewardHistory, error) {
+	mappingUnits, ok := new(big.Int).SetString(m.MappingUnits, 0)
+	if !ok {
+		return nil, fmt.Errorf("invalid mapping units value")
+	}
+	rewards, ok := new(big.Int).SetString(m.Rewards, 0)
+	if !ok {
+		return nil, fmt.Errorf("invalid rewards units value")
+	}
+
+	return &types.MapperRewardHistory{
+		// ID of the mapper
+		MapperID: types.IDFromString(m.MapperID),
+		// Date these rewards where issued
+		Date: m.Date,
+		// The total amount of MappingUnits the mapper got rewards for
+		MappingUnits: mappingUnits,
+		// The reward in THIX "gweis" for this mapper
+		Rewards: rewards,
+	}, nil
 }

--- a/rewards/store/clouddatastore/store.go
+++ b/rewards/store/clouddatastore/store.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ThingsIXFoundation/data-aggregator/clouddatastore"
 	"github.com/ThingsIXFoundation/data-aggregator/config"
 	"github.com/ThingsIXFoundation/data-aggregator/rewards/store/clouddatastore/models"
+	"github.com/ThingsIXFoundation/data-aggregator/utils"
 	"github.com/ThingsIXFoundation/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/viper"
@@ -152,4 +153,158 @@ func (s *Store) GetLatestRewardsDate(ctx context.Context) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return dbAccountRewardHistory.Date, nil
+}
+
+func (s *Store) GetAccountRewards(ctx context.Context, account common.Address, limit int, cursor string) ([]*types.AccountRewardHistory, string, error) {
+	q := datastore.NewQuery((&models.DBAccountRewardHistory{}).Entity()).
+		FilterField("Account", "=", utils.AddressToString(account)).
+		Limit(limit + 1).Order("-Date")
+
+	if cursor != "" {
+		cursorObj, err := datastore.DecodeCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		q = q.Start(cursorObj)
+	}
+
+	var (
+		count     = 0
+		reward    models.DBAccountRewardHistory
+		rewards   []*types.AccountRewardHistory
+		cursorObj datastore.Cursor
+		it        = s.client.Run(ctx, q)
+	)
+
+	_, err := it.Next(&reward)
+	for err == nil {
+		r, derr := reward.AccountRewardHistory()
+		if derr != nil {
+			return nil, "", derr
+		}
+		rewards = append(rewards, r)
+
+		count++
+
+		if count == limit {
+			cursorObj, err = it.Cursor()
+			if err != nil {
+				return nil, "", err
+			}
+			if _, err = it.Next(&reward); err != nil {
+				break
+			}
+		}
+
+		_, err = it.Next(&reward)
+	}
+
+	if err != iterator.Done {
+		return nil, "", err
+	}
+
+	return rewards, cursorObj.String(), nil
+}
+
+func (s *Store) GetMapperRewards(ctx context.Context, mapperID types.ID, limit int, cursor string) ([]*types.MapperRewardHistory, string, error) {
+	q := datastore.NewQuery((&models.DBMapperRewardHistory{}).Entity()).
+		FilterField("MapperID", "=", mapperID.String()).
+		Limit(limit + 1).Order("-Date")
+
+	if cursor != "" {
+		cursorObj, err := datastore.DecodeCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		q = q.Start(cursorObj)
+	}
+
+	var (
+		count     = 0
+		reward    models.DBMapperRewardHistory
+		rewards   []*types.MapperRewardHistory
+		cursorObj datastore.Cursor
+		it        = s.client.Run(ctx, q)
+	)
+
+	_, err := it.Next(&reward)
+	for err == nil {
+		r, derr := reward.MapperRewardHistory()
+		if derr != nil {
+			return nil, "", derr
+		}
+		rewards = append(rewards, r)
+
+		count++
+
+		if count == limit {
+			cursorObj, err = it.Cursor()
+			if err != nil {
+				return nil, "", err
+			}
+			if _, err = it.Next(&reward); err != nil {
+				break
+			}
+		}
+
+		_, err = it.Next(&reward)
+	}
+
+	if err != iterator.Done {
+		return nil, "", err
+	}
+
+	return rewards, cursorObj.String(), nil
+
+}
+
+func (s *Store) GetGatewayRewards(ctx context.Context, gatewayID types.ID, limit int, cursor string) ([]*types.GatewayRewardHistory, string, error) {
+	q := datastore.NewQuery((&models.DBGatewayRewardHistory{}).Entity()).
+		FilterField("GatewayID", "=", gatewayID.String()).
+		Limit(limit + 1).Order("-Date")
+
+	if cursor != "" {
+		cursorObj, err := datastore.DecodeCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		q = q.Start(cursorObj)
+	}
+
+	var (
+		count     = 0
+		reward    models.DBGatewayRewardHistory
+		rewards   []*types.GatewayRewardHistory
+		cursorObj datastore.Cursor
+		it        = s.client.Run(ctx, q)
+	)
+
+	_, err := it.Next(&reward)
+	for err == nil {
+		r, derr := reward.GatewayRewardHistory()
+		if derr != nil {
+			return nil, "", derr
+		}
+		rewards = append(rewards, r)
+
+		count++
+
+		if count == limit {
+			cursorObj, err = it.Cursor()
+			if err != nil {
+				return nil, "", err
+			}
+			if _, err = it.Next(&reward); err != nil {
+				break
+			}
+		}
+
+		_, err = it.Next(&reward)
+	}
+
+	if err != iterator.Done {
+		return nil, "", err
+	}
+
+	return rewards, cursorObj.String(), nil
 }

--- a/rewards/store/store.go
+++ b/rewards/store/store.go
@@ -39,6 +39,10 @@ type Store interface {
 	GetAccountRewardsAt(ctx context.Context, account common.Address, at time.Time) (*types.AccountRewardHistory, error)
 	GetAllAccountRewardsAt(ctx context.Context, at time.Time) ([]*types.AccountRewardHistory, error)
 
+	GetAccountRewards(ctx context.Context, account common.Address, limit int, cursor string) ([]*types.AccountRewardHistory, string, error)
+	GetMapperRewards(ctx context.Context, mapperID types.ID, limit int, cursor string) ([]*types.MapperRewardHistory, string, error)
+	GetGatewayRewards(ctx context.Context, gatewayID types.ID, limit int, cursor string) ([]*types.GatewayRewardHistory, string, error)
+
 	GetLatestRewardsDate(ctx context.Context) (time.Time, error)
 }
 


### PR DESCRIPTION
Adds endpoints to retrieve account, gateway and mapper rewards. Also includes a bugfix where the account address in account reward history records was written checksummed.